### PR TITLE
Remove parent field from AndOrNode

### DIFF
--- a/src/main/java/seedu/jarvis/commons/util/andor/AndNode.java
+++ b/src/main/java/seedu/jarvis/commons/util/andor/AndNode.java
@@ -16,12 +16,12 @@ import seedu.jarvis.model.course.Course;
 public class AndNode extends AndOrNode {
     private static final String STRING_FORM = "all of";
 
-    protected AndNode(Course data, AndOrNode parent, List<AndOrNode> children) {
-        super(data, parent, children);
+    protected AndNode(Course data, List<AndOrNode> children) {
+        super(data, children);
     }
 
-    protected AndNode(Course data, AndOrNode parent) {
-        super(data, parent);
+    protected AndNode(Course data) {
+        super(data);
     }
 
     @Override

--- a/src/main/java/seedu/jarvis/commons/util/andor/AndOrNode.java
+++ b/src/main/java/seedu/jarvis/commons/util/andor/AndOrNode.java
@@ -27,18 +27,15 @@ import seedu.jarvis.model.course.Course;
  */
 public abstract class AndOrNode {
     protected Course data;
-    protected AndOrNode parent;
     protected List<AndOrNode> children;
 
-    protected AndOrNode(Course data, AndOrNode parent, List<AndOrNode> children) {
+    protected AndOrNode(Course data, List<AndOrNode> children) {
         this.data = data;
-        this.parent = parent;
         this.children = children;
     }
 
-    protected AndOrNode(Course data, AndOrNode parent) {
+    protected AndOrNode(Course data) {
         this.data = data;
-        this.parent = parent;
         this.children = new ArrayList<>();
     }
 
@@ -67,18 +64,17 @@ public abstract class AndOrNode {
     /**
      * Returns an {@code AND} or {@code OR} node.
      *
-     * @param parent of this node to be created
      * @param type of the node as a {@code String}
      * @return a new {@AndOr} node
      */
-    public static AndOrNode createAndOrNode(AndOrNode parent, String... type) {
+    public static AndOrNode createAndOrNode(String... type) {
         String nodeType = type.length == 0 ? "" : type[0];
         AndOrOperation andOrNodeType = AndOrOperationMapperUtil.resolveType(nodeType);
         switch (andOrNodeType) {
         case AND:
-            return new AndNode(null, parent);
+            return new AndNode(null);
         case OR:
-            return new OrNode(null, parent);
+            return new OrNode(null);
         default:
             return null;
         }
@@ -88,11 +84,10 @@ public abstract class AndOrNode {
      * Returns a {@code LEAF} node.
      *
      * @param data course data of the node
-     * @param parent of this node to be created
      * @return a new {@AndOr} node
      */
-    public static AndOrNode createLeafNode(Course data, AndOrNode parent) {
-        return new LeafNode(data, parent);
+    public static AndOrNode createLeafNode(Course data) {
+        return new LeafNode(data);
     }
 
     /**

--- a/src/main/java/seedu/jarvis/commons/util/andor/AndOrTree.java
+++ b/src/main/java/seedu/jarvis/commons/util/andor/AndOrTree.java
@@ -52,7 +52,7 @@ public class AndOrTree {
             throw new IOException(courseCode + " could not be found");
         }
 
-        AndOrNode rootNode = AndOrNode.createLeafNode(course, null);
+        AndOrNode rootNode = AndOrNode.createLeafNode(course);
         JsonNode node;
 
         try {
@@ -83,7 +83,7 @@ public class AndOrTree {
      * Handles the case where the current JsonNode is an object.
      */
     private static void handleObject(JsonNode node, AndOrNode curr) {
-        AndOrNode newNode = AndOrNode.createAndOrNode(curr, getKey(node));
+        AndOrNode newNode = AndOrNode.createAndOrNode(getKey(node));
         curr.insert(newNode);
         node.fields().forEachRemaining(field -> {
             buildTree(field.getValue(), newNode);
@@ -111,7 +111,7 @@ public class AndOrTree {
             // course is likely no longer being offered
             return;
         }
-        AndOrNode newNode = AndOrNode.createLeafNode(leaf, curr);
+        AndOrNode newNode = AndOrNode.createLeafNode(leaf);
         curr.insert(newNode);
     }
 

--- a/src/main/java/seedu/jarvis/commons/util/andor/LeafNode.java
+++ b/src/main/java/seedu/jarvis/commons/util/andor/LeafNode.java
@@ -14,12 +14,12 @@ public class LeafNode extends AndOrNode {
     /** Return if data is {@code null} */
     private static final String EMPTY_FORM = "null";
 
-    protected LeafNode(Course data, AndOrNode parent, List<AndOrNode> children) {
-        super(data, parent, children);
+    protected LeafNode(Course data, List<AndOrNode> children) {
+        super(data, children);
     }
 
-    protected LeafNode(Course data, AndOrNode parent) {
-        super(data, parent);
+    protected LeafNode(Course data) {
+        super(data);
     }
 
     private boolean isNull() {

--- a/src/main/java/seedu/jarvis/commons/util/andor/OrNode.java
+++ b/src/main/java/seedu/jarvis/commons/util/andor/OrNode.java
@@ -15,12 +15,12 @@ import seedu.jarvis.model.course.Course;
 public class OrNode extends AndOrNode {
     private static final String STRING_FORM = "one of";
 
-    protected OrNode(Course data, AndOrNode parent, List<AndOrNode> children) {
-        super(data, parent, children);
+    protected OrNode(Course data, List<AndOrNode> children) {
+        super(data, children);
     }
 
-    protected OrNode(Course data, AndOrNode parent) {
-        super(data, parent);
+    protected OrNode(Course data) {
+        super(data);
     }
 
     @Override

--- a/src/test/java/seedu/jarvis/commons/util/andor/AndNodeTest.java
+++ b/src/test/java/seedu/jarvis/commons/util/andor/AndNodeTest.java
@@ -31,19 +31,18 @@ public class AndNodeTest {
 
     @Test
     public void hasFulfilledCondition_validInput_returnsTrue() {
-        AndNode an = new AndNode(null, null, CHILDREN);
+        AndNode an = new AndNode(null, CHILDREN);
         assertTrue(() -> an.hasFulfilledCondition(COLLECTION_PASSES_REQUIREMENTS));
     }
 
     @Test
     public void hasFulfilledCondition_invalidInput_returnsFalse() {
-        AndNode an = new AndNode(null, null, CHILDREN);
+        AndNode an = new AndNode(null, CHILDREN);
         assertFalse(() -> an.hasFulfilledCondition(COLLECTION_FAILS_REQUIREMENTS));
     }
 
     @Test
     public void toString_returnsStringForm() {
-        assertEquals("all of",
-                new AndNode(null, null, null).toString());
+        assertEquals("all of", new AndNode(null, null).toString());
     }
 }

--- a/src/test/java/seedu/jarvis/commons/util/andor/AndOrNodeTest.java
+++ b/src/test/java/seedu/jarvis/commons/util/andor/AndOrNodeTest.java
@@ -16,39 +16,39 @@ public class AndOrNodeTest {
 
     @Test
     public void createAndOrNode_validInputs_returnsCorrectNode() {
-        assertTrue(AndOrNode.createAndOrNode(null, "and") instanceof AndNode);
-        assertTrue(AndOrNode.createAndOrNode(null, "or") instanceof OrNode);
+        assertTrue(AndOrNode.createAndOrNode("and") instanceof AndNode);
+        assertTrue(AndOrNode.createAndOrNode("or") instanceof OrNode);
         for (String invalid : CREATE_NODE_INVALID_INPUTS) {
-            assertTrue(AndOrNode.createAndOrNode(null, invalid) == null);
+            assertTrue(AndOrNode.createAndOrNode(invalid) == null);
         }
     }
 
     @Test
     public void createLeafNode_validInputs_returnsNotNull() {
-        assertTrue(AndOrNode.createLeafNode(null, null) instanceof LeafNode);
+        assertTrue(AndOrNode.createLeafNode(null) instanceof LeafNode);
         for (String any : CREATE_NODE_INVALID_INPUTS) {
-            assertTrue(AndOrNode.createLeafNode(new CourseStub(any), null) instanceof LeafNode);
+            assertTrue(AndOrNode.createLeafNode(new CourseStub(any)) instanceof LeafNode);
         }
     }
 
     @Test
     public void insert_validNode_success() {
-        AndOrNode node = AndOrNode.createAndOrNode(null, "and");
-        AndOrNode anotherNode = AndOrNode.createLeafNode(new CourseStub(""), null);
+        AndOrNode node = AndOrNode.createAndOrNode("and");
+        AndOrNode anotherNode = AndOrNode.createLeafNode(new CourseStub(""));
         node.insert(anotherNode);
         assertTrue(node.getChildren().contains(anotherNode));
     }
 
     @Test
     public void toTreeString_validTree_returnsCorrectString() {
-        AndOrNode node = AndOrNode.createAndOrNode(null, "and");
-        AndOrNode child1 = AndOrNode.createAndOrNode(null, "or");
-        child1.insert(AndOrNode.createLeafNode(new CourseStub("t1"), null));
-        child1.insert(AndOrNode.createLeafNode(new CourseStub("t2"), null));
+        AndOrNode node = AndOrNode.createAndOrNode("and");
+        AndOrNode child1 = AndOrNode.createAndOrNode("or");
+        child1.insert(AndOrNode.createLeafNode(new CourseStub("t1")));
+        child1.insert(AndOrNode.createLeafNode(new CourseStub("t2")));
         node.insert(child1);
-        node.insert(AndOrNode.createLeafNode(new CourseStub("t3"), null));
-        node.insert(AndOrNode.createLeafNode(new CourseStub("t4"), null));
-        node.insert(AndOrNode.createLeafNode(new CourseStub("t5"), null));
+        node.insert(AndOrNode.createLeafNode(new CourseStub("t3")));
+        node.insert(AndOrNode.createLeafNode(new CourseStub("t4")));
+        node.insert(AndOrNode.createLeafNode(new CourseStub("t5")));
 
         String correctString = "all of\n├── one of\n│   "
                 + "├── t1\n│   └── t2\n├── t3\n├── t4\n└── t5\n";

--- a/src/test/java/seedu/jarvis/commons/util/andor/AndOrStubsUtil.java
+++ b/src/test/java/seedu/jarvis/commons/util/andor/AndOrStubsUtil.java
@@ -49,7 +49,7 @@ public class AndOrStubsUtil {
      */
     protected static class NodeStub extends AndOrNode {
         public NodeStub(CourseStub data) {
-            super(data, null, null);
+            super(data, null);
         }
 
         public boolean hasFulfilledCondition(Collection<Course> collection) {

--- a/src/test/java/seedu/jarvis/commons/util/andor/OrNodeTest.java
+++ b/src/test/java/seedu/jarvis/commons/util/andor/OrNodeTest.java
@@ -30,20 +30,20 @@ public class OrNodeTest {
 
     @Test
     public void hasFulfilledCondition_validInput_returnsTrue() {
-        OrNode or = new OrNode(null, null, CHILDREN);
+        OrNode or = new OrNode(null, CHILDREN);
         assertTrue(() -> or.hasFulfilledCondition(COLLECTION_PASSES_REQUIREMENTS_SINGLE));
         assertTrue(() -> or.hasFulfilledCondition(COLLECTION_PASSES_REQUIREMENTS_MULTIPLE));
     }
 
     @Test
     public void hasFulfilledCondition_invalidInput_returnsFalse() {
-        OrNode or = new OrNode(null, null, CHILDREN);
+        OrNode or = new OrNode(null, CHILDREN);
         assertFalse(() -> or.hasFulfilledCondition(COLLECTION_FAILS_REQUIREMENTS));
     }
 
     @Test
     public void toString_returnsStringForm() {
         assertEquals("one of",
-                new OrNode(null, null, null).toString());
+                new OrNode(null, null).toString());
     }
 }


### PR DESCRIPTION
Remove `parent` field from the abstract class `AndOrNode` class as it complicates the constructors of concrete classes of `AndOrNode` and does not serve any purpose in the implementation of the `AndOrTree`.