### PR TITLE
Add CourseNotFoundException

### DIFF
--- a/src/main/java/seedu/jarvis/commons/exceptions/CourseNotFoundException.java
+++ b/src/main/java/seedu/jarvis/commons/exceptions/CourseNotFoundException.java
@@ -1,0 +1,11 @@
+package seedu.jarvis.commons.exceptions;
+
+public class CourseNotFoundException extends Exception {
+    public CourseNotFoundException(String message) {
+        super(message);
+    }
+
+    public CourseNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/seedu/jarvis/commons/exceptions/CourseNotFoundException.java
+++ b/src/main/java/seedu/jarvis/commons/exceptions/CourseNotFoundException.java
@@ -1,5 +1,8 @@
 package seedu.jarvis.commons.exceptions;
 
+/**
+ * Signals that a course could not be found.
+ */
 public class CourseNotFoundException extends Exception {
     public CourseNotFoundException(String message) {
         super(message);

--- a/src/main/java/seedu/jarvis/commons/util/andor/AndOrTree.java
+++ b/src/main/java/seedu/jarvis/commons/util/andor/AndOrTree.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import seedu.jarvis.commons.exceptions.CourseNotFoundException;
 import seedu.jarvis.commons.util.CourseUtil;
 import seedu.jarvis.model.course.Course;
 
@@ -43,18 +44,11 @@ public class AndOrTree {
      * @throws IOException if the course file could not be found
      */
     public static AndOrTree buildTree(String courseCode)
-            throws IOException {
+            throws CourseNotFoundException {
         Course course;
-
-        try {
-            course = CourseUtil.getCourse(courseCode);
-        } catch (IOException e) {
-            throw new IOException(courseCode + " could not be found");
-        }
-
+        course = CourseUtil.getCourse(courseCode);
         AndOrNode rootNode = AndOrNode.createLeafNode(course, null);
         JsonNode node;
-
         try {
             String prereqTree = course.getPrereqTree().toString();
             prereqTree = CourseUtil.addQuotes(prereqTree);
@@ -62,6 +56,8 @@ public class AndOrTree {
             buildTree(node, rootNode);
         } catch (NullPointerException e) {
             // return empty tree
+        } catch (IOException e) {
+            throw new CourseNotFoundException("course not found");
         }
         return new AndOrTree(rootNode);
     }
@@ -106,7 +102,7 @@ public class AndOrTree {
         Course leaf;
         try {
             leaf = CourseUtil.getCourse(node.asText());
-        } catch (IOException e) {
+        } catch (CourseNotFoundException e) {
             // do not create the node -> if the file does not exist, means the
             // course is likely no longer being offered
             return;

--- a/src/test/java/seedu/jarvis/commons/util/CourseUtilTest.java
+++ b/src/test/java/seedu/jarvis/commons/util/CourseUtilTest.java
@@ -3,10 +3,9 @@ package seedu.jarvis.commons.util;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.IOException;
-
 import org.junit.jupiter.api.Test;
 
+import seedu.jarvis.commons.exceptions.CourseNotFoundException;
 
 
 /**
@@ -56,9 +55,10 @@ public class CourseUtilTest {
 
 
     @Test
-    public void getCourseJsonString_invalidInput_throwsIoException() {
+    public void getCourseJsonString_invalidInput_throwsException() {
         for (String course : INVALID_COURSE_CODES) {
-            assertThrows(IOException.class, () -> CourseUtil.getCourseJsonString(course));
+            assertThrows(
+                CourseNotFoundException.class, () -> CourseUtil.getCourseJsonString(course));
         }
     }
 
@@ -70,9 +70,10 @@ public class CourseUtilTest {
     }
 
     @Test
-    public void getJsonMap_invalidInput_throwsIoException() {
+    public void getJsonMap_invalidInput_throwsException() {
         for (String course : INVALID_COURSE_CODES) {
-            assertThrows(IOException.class, () -> CourseUtil.getCourseJsonString(course));
+            assertThrows(
+                CourseNotFoundException.class, () -> CourseUtil.getCourseJsonString(course));
         }
     }
 
@@ -84,9 +85,9 @@ public class CourseUtilTest {
     }
 
     @Test
-    public void getCourse_invalidInput_throwsIoOException() {
+    public void getCourse_invalidInput_throwsException() {
         for (String course : INVALID_COURSE_CODES) {
-            assertThrows(IOException.class, () -> CourseUtil.getCourse(course));
+            assertThrows(CourseNotFoundException.class, () -> CourseUtil.getCourse(course));
         }
     }
 }

--- a/src/test/java/seedu/jarvis/commons/util/andor/AndOrTreeTest.java
+++ b/src/test/java/seedu/jarvis/commons/util/andor/AndOrTreeTest.java
@@ -9,12 +9,12 @@ import static seedu.jarvis.commons.util.CourseUtilTest.INVALID_COURSE_CODES;
 import static seedu.jarvis.commons.util.CourseUtilTest.VALID_COURSE_CODES;
 import static seedu.jarvis.commons.util.CourseUtilTest.VALID_COURSE_CODES_NO_PREREQ;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.jarvis.commons.exceptions.CourseNotFoundException;
 import seedu.jarvis.commons.util.CourseUtil;
 import seedu.jarvis.model.course.Course;
 
@@ -31,9 +31,9 @@ public class AndOrTreeTest {
     }
 
     @Test
-    public void buildTree_invalidCourse_throwsIoException() {
+    public void buildTree_invalidCourse_throwsException() {
         for (String course : INVALID_COURSE_CODES) {
-            assertThrows(IOException.class, () -> AndOrTree.buildTree(course));
+            assertThrows(CourseNotFoundException.class, () -> AndOrTree.buildTree(course));
         }
     }
 
@@ -54,7 +54,7 @@ public class AndOrTreeTest {
     }
 
     @Test
-    public void fulfillsCondition_sufficientRequirements_returnsTrueAndDoesNotThrowsException() {
+    public void fulfillsCondition_sufficientRequirements_returnsTrueAndDoesNotThrowException() {
         assertDoesNotThrow(() -> {
             Map<String, List<Course>> toTest = Map.of(
                 "CS3244", List.of(


### PR DESCRIPTION
The `andor` package and `CourseUtil` class originally threw Java's generic `IOException` to indicate a File I/O exception (e.g not finding the course file).

This replaces all instances of `IOException` inside the `andor` package and the `CourseUtil` class (and corresponding test classes) with a new custom exception `CourseNotFoundException`.