### PR TITLE
Modify build.gradle to include additional compiler flags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,7 +143,12 @@ asciidoctor {
     }
 
     compileJava {
-        options.compilerArgs += ["-Xlint:unchecked"]
+        options.compilerArgs += ["-Xlint:unchecked", "-Xlint:deprecation"]
+        options.fork = true
+    }
+
+    compileTestJava {
+        options.compilerArgs += ["-Xlint:unchecked", "-Xlint:deprecation"]
         options.fork = true
     }
 }


### PR DESCRIPTION
`-Xlint:unchecked` will enable verbose compiler warnings associated with Generics  
`-Xlink:deprecation` does the same for warnings associated with API labeled as deprecated.

This adds the compiler flags to both `compileJava` and `compileTestJava` using `build.gradle`.